### PR TITLE
Updated to support mysql cookbook 5.0.0

### DIFF
--- a/recipes/db.rb
+++ b/recipes/db.rb
@@ -6,7 +6,7 @@
 #
 
 # Install MySQL server & MySQL client
-include_recipe "mysql"
+include_recipe "mysql::client"
 include_recipe "mysql::server"
 
 # Create database if it doesn't exist


### PR DESCRIPTION
This is a fix for those that are receiving this error.

```
Chef::Exceptions::RecipeNotFound
--------------------------------
could not find recipe default for cookbook mysql


[2014-04-02T09:28:04+00:00] ERROR: Running exception handlers
[2014-04-02T09:28:04+00:00] ERROR: Exception handlers complete
[2014-04-02T09:28:04+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
[2014-04-02T09:28:04+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```
