### PR TITLE
Added the option to specify Apache environment variables

### DIFF
--- a/templates/default/web_app.conf.erb
+++ b/templates/default/web_app.conf.erb
@@ -16,6 +16,7 @@
     AllowOverride None
   </Directory>
 
+  <% @node[:laravel][:server_env].each do |env| %><%= 'SetEnv '+env+"\n"%> <% end %>
   php_flag display_startup_errors on
   php_flag display_errors on
   php_flag html_errors on


### PR DESCRIPTION
Updated the web_app template to allow user to specify apache environment variables

Apache environment variables can be set in the Vagrantfile. Example:

```
chef.json = {
  :laravel => {
    :server_env     => ['APP_ENV local'],
```
